### PR TITLE
Updating xm commands to xl and fixed a few conditionals.

### DIFF
--- a/lib/system/command.rb
+++ b/lib/system/command.rb
@@ -44,10 +44,10 @@ module System
 
     def log
       case @command_level
-      when LEVEL_WARN: 
+      when LEVEL_WARN
           logger.warn(error_message)
           raise System::Exception::WarningException.new(error_message, command, exit_status)
-      when LEVEL_FATAL: 
+      when LEVEL_FATAL 
           logger.fatal(error_message)
           raise System::Exception::CriticalException.new(error_message, command, exit_status)
       end

--- a/lib/xen/instance.rb
+++ b/lib/xen/instance.rb
@@ -19,7 +19,7 @@ module Xen
 
       # Gets all running instances on dom0
       def all
-        get_all = System::Command.new("sudo xm list" , :command_level => 2)
+        get_all = System::Command.new("sudo xl list" , :command_level => 2)
         get_all.execute
         return [] unless get_all.exit_status == 0
 
@@ -30,7 +30,7 @@ module Xen
       # ==Params:
       # => +name+:  Name of instance
       def find_by_name(name)
-        find = System::Command.new("sudo xm list #{name}", :command_level => 1,
+        find = System::Command.new("sudo xl list #{name}", :command_level => 1,
                                   :message => "Can't find running domU with name: #{name}")
         find.execute
         instance_from_output(find.output.split("\n").last) if find.exit_status == 0
@@ -39,7 +39,7 @@ module Xen
 
       # Gets all attributs of an instance
       def find_attributes_by_name(name)
-        find = System::Command.new("sudo xm list #{name}", :command_level => 1)
+        find = System::Command.new("sudo xl list #{name}", :command_level => 1)
         find.execute
         attributes_from_output(find.output) if find.exit_status == 0
       end
@@ -112,37 +112,37 @@ module Xen
     end
 
     def start
-      start = System::Command.new("sudo xm create #{name}.cfg", :command_level => 2, :message => "Can't start #{name} domU")
+      start = System::Command.new("sudo xl create #{name}.cfg", :command_level => 2, :message => "Can't start #{name} domU")
       start.execute
     end
 
 
     def reboot
-      reboot = System::Command.new("sudo xm reboot #{dom_id}", :command_level => 2, :message => "Can't reboot #{name} domU")
+      reboot = System::Command.new("sudo xl reboot #{dom_id}", :command_level => 2, :message => "Can't reboot #{name} domU")
       reboot.execute
     end
 
     def shutdown
-      shutdown = System::Command.new("sudo xm shutdown #{dom_id}", :command_level => 2, :message => "Can't shutdown #{name} domU")
+      shutdown = System::Command.new("sudo xl shutdown #{dom_id}", :command_level => 2, :message => "Can't shutdown #{name} domU")
       shutdown.execute
     end
 
     def migrate(destination)
-      migrate = System::Command.new("sudo xm migrate --live #{name} #{destination}", 
+      migrate = System::Command.new("sudo xl migrate --live #{name} #{destination}", 
                             :command_level => 2,
                             :message => "Can't migrate #{name} domU to #{destination}")
       migrate.execute
     end
 
     def destroy
-      destroy = System::Command.new("sudo xm destroy #{dom_id}", :command_level => 2,
+      destroy = System::Command.new("sudo xl destroy #{dom_id}", :command_level => 2,
                             :message => "Can't destroy #{name} domU")
       destroy.execute
     end
 
     def pause
       unless paused?
-        pause = System::Command.new("sudo xm pause #{dom_id}", :command_level => 1,
+        pause = System::Command.new("sudo xl pause #{dom_id}", :command_level => 1,
                             :message => "Can't pause #{name} domU")
         pause.execute
       end
@@ -150,7 +150,7 @@ module Xen
 
     def unpause
       if paused?
-        unpause = System::Command.new("sudo xm unpause #{dom_id}", :command_level => 1,
+        unpause = System::Command.new("sudo xl unpause #{dom_id}", :command_level => 1,
                             :message => "Can't unpause #{name} domU")
         unpause.execute
       end
@@ -159,12 +159,12 @@ module Xen
     # Which state have the instance
     def state_text
       case state
-      when STATE_RUNNING: 'running'
-      when STATE_BLOCKED: 'blocked'
-      when STATE_SHUTDOWN: 'shutdown'
-      when STATE_CRASHED: 'crashed'
-      when STATE_DYING: 'dying'
-      when STATE_PAUSED: 'paused'
+      when STATE_RUNNING == 'running'
+      when STATE_BLOCKED == 'blocked'
+      when STATE_SHUTDOWN == 'shutdown'
+      when STATE_CRASHED == 'crashed'
+      when STATE_DYING == 'dying'
+      when STATE_PAUSED == 'paused'
       end
     end
 


### PR DESCRIPTION
The current version of Xen Hypervisor 4.7.* uses the command 'xl' instead of 'xm'. Also, some ruby conditionals appear to have changed from a ':' to '==' using Ruby 2.2.*